### PR TITLE
Add Command Line Options to Fedy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,6 @@
     "no-new": 2,
     "no-octal-escape": 2,
     "no-octal": 2,
-    "no-octal-escape": 2,
     "no-param-reassign": 1,
     "no-process-env": 0,
     "no-proto": 2,

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 #!/usr/bin/gjs
 
+imports.searchPath.unshift('.');
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
@@ -7,6 +8,8 @@ const GdkPixbuf = imports.gi.GdkPixbuf;
 const Notify = imports.gi.Notify;
 const Pango = imports.gi.Pango;
 const Lang = imports.lang;
+const System = imports.system;
+const FedyCli = imports.cli.FedyCli;
 
 const APP_NAME = "Fedy";
 
@@ -21,6 +24,8 @@ const Application = new Lang.Class({
 
         this.application.connect("activate", Lang.bind(this, this._onActivate));
         this.application.connect("startup", Lang.bind(this, this._onStartup));
+
+        this.cli = new FedyCli(this);
 
         Notify.init(APP_NAME);
     },
@@ -710,4 +715,5 @@ const Application = new Lang.Class({
 
 let app = new Application();
 
-app.application.run(ARGV);
+// app.application.run(ARGV);
+app.application.run([System.programInvocationName].concat(ARGV));

--- a/app.js
+++ b/app.js
@@ -715,5 +715,4 @@ const Application = new Lang.Class({
 
 let app = new Application();
 
-// app.application.run(ARGV);
 app.application.run([System.programInvocationName].concat(ARGV));

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const Pango = imports.gi.Pango;
 const Lang = imports.lang;
 const System = imports.system;
 const FedyCli = imports.cli.FedyCli;
+const ByteArray = imports.byteArray;
 
 const APP_NAME = "Fedy";
 
@@ -123,8 +124,8 @@ const Application = new Lang.Class({
 
             try {
                 let data = file.read(null).read_bytes(size, null).get_data();
-
-                parsed = JSON.parse(data);
+                let content = (data instanceof Uint8Array) ? ByteArray.toString(data) : data.toString();
+                parsed = JSON.parse(content);
             } catch (e) {
                 print("Error loading file " + file.get_path() + " : " + e.message);
             }
@@ -257,10 +258,11 @@ const Application = new Lang.Class({
                     try {
                         let stream = file.open_readwrite(null).get_input_stream();
                         let data = stream.read_bytes(size, null).get_data();
+                        let content = (data instanceof Uint8Array) ? ByteArray.toString(data) : data.toString();
 
                         stream.close(null);
 
-                        let lines = (data + "").split(/\n/);
+                        let lines = content.split(/\n/);
 
                         parts = parts.concat(lines);
                     } catch (e) {

--- a/cli.js
+++ b/cli.js
@@ -176,9 +176,9 @@ var FedyCli = new Lang.Class({
                 `run the command '${pluginStatus.maliciousPart}' ` +
                 `which might ${pluginStatus.maliciousDescription}. Use -f option to force the execution.`;
         } else if (commandStatusCode === 0) {
-            report = `✓ ${reportPrefix} (${pluginStatus.action.label}) "successfully completed"`;
+            report = `✓ ${reportPrefix} (${pluginStatus.action.label}) successfully completed`;
         } else {
-            report = `✗ ${reportPrefix} (${pluginStatus.action.label}) "failed"`;
+            report = `✗ ${reportPrefix} (${pluginStatus.action.label}) failed`;
         }
 
         return report;

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,215 @@
+/* global print, logError */
+
+const
+    GLib = imports.gi.GLib,
+    Lang = imports.lang,
+    Option = imports.option.Option,
+    PluginRepository = imports.repository.PluginRepository;
+
+const
+    FedyOption = {
+        LIST: new Option("list", GLib.OptionArg.NONE, "List available plugins", null, false),
+        THICK: new Option("thick", GLib.OptionArg.NONE, "Compact output when listing available plugins", null, false),
+        STATUS: new Option("status", GLib.OptionArg.STRING_ARRAY, "Report plugin status", "<plugin>", true),
+        EXEC: new Option("exec", GLib.OptionArg.STRING_ARRAY, "Execute plugin action", "<plugin>", true),
+        UNDO: new Option("undo", GLib.OptionArg.STRING_ARRAY, "Undo plugin action", "<plugin>", true),
+        FORCE: new Option("force", GLib.OptionArg.NONE, "Force plugins action", null, false)
+    },
+    FedyOptions = [ FedyOption.LIST, FedyOption.THICK,
+        FedyOption.STATUS, FedyOption.EXEC, FedyOption.UNDO, FedyOption.FORCE ];
+
+
+var PluginAction = new Lang.Class({
+    Name: "PluginAction",
+
+    _init(option, plugin, forced) {
+        this.option = option;
+        this.plugin = plugin;
+        this.forced = forced;
+    },
+
+    actionLabel() {
+        return this.option.name.charAt(0).toUpperCase() + this.option.name.substr(1);
+    },
+
+    pluginLabel() {
+        return (this.isPluginUnknown()) ? this.plugin.name : this.plugin.label;
+    },
+
+    isCommand() {
+        return !this.isPluginUnknown() && !this.isStatus();
+    },
+
+    isPluginUnknown() {
+        return typeof this.plugin.label === "undefined";
+    },
+
+    isStatus() {
+        return FedyOption.STATUS.match(this.option.name);
+    }
+});
+
+var FedyCli = new Lang.Class({
+    Name: "FedyCli",
+
+    _init(fedy) {
+        FedyOptions.forEach(option => option.registerIn(fedy.application));
+
+        this.fedy = fedy;
+        fedy.application.set_option_context_parameter_string("app.js");
+        fedy.application.set_option_context_description("");
+        fedy.application.set_option_context_summary(
+            "  fedy --list [--thick]\n" +
+            "  fedy [--force] [--status <plugin>]... [--undo <plugin>]... [--exec <plugin>]..."
+        );
+
+        this.fedy.application.connect("handle_local_options", Lang.bind(this, this._onOptions));
+    },
+
+    _onOptions(application, options) {
+        if (!this._isCliOptions(options)) {
+            return -1;
+        }
+
+        this.pluginRepository = new PluginRepository(this.fedy);
+
+        const loop = GLib.MainLoop.new(null, false);
+        let promiseOfReports = (FedyOption.LIST.in(options)) ?
+            this._promiseOfCategoryReports(options) :
+            this._promiseOfActionReports(options);
+
+        Promise
+            .all(promiseOfReports)
+            .then(reports => this._printReports(reports))
+            .then(() => loop.quit());
+
+        loop.run();
+
+        return 0;
+    },
+
+    _isCliOptions(options) {
+        return FedyOptions.some(option => option.in(options));
+    },
+
+    _promiseOfCategoryReports(options) {
+        const compact = FedyOption.THICK.in(options);
+        return this.pluginRepository
+            .listCategories()
+            .map(category => {
+                const promiseOfPluginsWithStatuses = this.pluginRepository
+                    .listByCategory(category)
+                    .map(plugin => this.pluginRepository
+                        .promiseOfPluginStatus(plugin)
+                        .then(pluginStatus => [ plugin, pluginStatus ]));
+
+                return Promise
+                    .all(promiseOfPluginsWithStatuses)
+                    .then(pluginsWithStatuses => this._buildCategoryReport(category, pluginsWithStatuses, compact));
+            });
+    },
+
+    _buildCategoryReport(category, pluginsWithStatuses, compact) {
+        let report = `Category: ${category}\n`;
+        pluginsWithStatuses.forEach(([ plugin, pluginStatus ]) => {
+            report += this._buildPluginReport(plugin, pluginStatus, compact);
+        });
+        report += "\n";
+        return report;
+    },
+
+    _buildPluginReport(plugin, pluginStatus, compact) {
+        const statusCharacter = pluginStatus.isPluginEnable() ? "✓" : "✗",
+            compactReport = `${statusCharacter} [${plugin.name}] ${plugin.label}\n`,
+            license = (typeof plugin.license !== "undefined") ? `  (${plugin.license})\n` : "";
+        return (compact) ? compactReport : `${compactReport}  ${plugin.description}\n${license}`;
+    },
+
+    _promiseOfActionReports: function (options) {
+        const forced = FedyOption.FORCE.in(options);
+        return FedyOptions
+            .filter(option => option.in(options) && option.isAction)
+            .flatMap(option => this._pluginActions(options, option, forced))
+            .map(pluginActions => this._promiseOfActionReport(pluginActions));
+    },
+
+    _pluginActions(options, option, forced) {
+        return option
+            .parameters(options)
+            .map(pluginName => {
+                let plugin = this.pluginRepository.getByName(pluginName);
+                return new PluginAction(option, plugin, forced);
+            });
+    },
+
+    _promiseOfActionReport(pluginAction) {
+        return this.pluginRepository
+            .promiseOfPluginStatus(pluginAction.plugin)
+            .then(pluginStatus => {
+                if (!this._isCommandRequired(pluginAction, pluginStatus)) {
+                    return this._buildReport(pluginAction, pluginStatus, 0);
+                }
+
+                return this.pluginRepository
+                    .promiseOfCommandStatus(pluginAction.plugin.path, pluginStatus.action.command)
+                    .then(commandStatusCode => this._buildReport(pluginAction, pluginStatus, commandStatusCode));
+            })
+            .catch(e => logError(e));
+    },
+
+    _buildReport(pluginAction, pluginStatus, commandStatusCode) {
+        const actionLabel = pluginAction.actionLabel(),
+            reportPrefix = `${actionLabel} of '${pluginAction.pluginLabel()}'`;
+
+        let report;
+        if (pluginAction.isPluginUnknown()) {
+            report = `✗ ${reportPrefix} fail: plugin name unknown`;
+        } else if (pluginAction.isStatus()) {
+            report = `✓ ${reportPrefix} ${(pluginStatus.isPluginEnable()) ? "enabled" : "disabled"}`;
+        } else if (this._isAlreadyApplied(pluginAction, pluginStatus)) {
+            report = `✓ ${reportPrefix} already done`;
+        } else if (pluginStatus.isMalicious && !pluginAction.forced) {
+            report = `✗ ${reportPrefix} aborted: the plugin is trying to ` +
+                `run the command '${pluginStatus.maliciousPart}' ` +
+                `which might ${pluginStatus.maliciousDescription}. Use -f option to force the execution.`;
+        } else if (commandStatusCode === 0) {
+            report = `✓ ${reportPrefix} (${pluginStatus.action.label}) "successfully completed"`;
+        } else {
+            report = `✗ ${reportPrefix} (${pluginStatus.action.label}) "failed"`;
+        }
+
+        return report;
+    },
+
+    _isCommandRequired(pluginAction, pluginStatus) {
+        const isAlreadyApplied = this._isAlreadyApplied(pluginAction, pluginStatus);
+        return !isAlreadyApplied && pluginAction.isCommand() && (!pluginStatus.isMalicious || pluginAction.forced);
+    },
+
+    _isAlreadyApplied(pluginAction, pluginStatus) {
+        switch (pluginAction.option.name) {
+        case FedyOption.EXEC.name:
+            return pluginStatus.code === 0;
+        case FedyOption.UNDO.name:
+            return pluginStatus.code !== 0;
+        default:
+            return false;
+        }
+    },
+
+    _printReports(reports) {
+        print();
+        print("-------");
+        reports.forEach(report => {
+            print(report);
+        });
+    }
+
+});
+
+const concat = (x, y) => x.concat(y),
+    flatMap = (f, xs) => xs.map(f).reduce(concat, []);
+Array.prototype.flatMap = function(f) {
+    return flatMap(f, this);
+};
+

--- a/cli.js
+++ b/cli.js
@@ -56,12 +56,15 @@ var FedyCli = new Lang.Class({
         FedyOptions.forEach(option => option.registerIn(fedy.application));
 
         this.fedy = fedy;
-        fedy.application.set_option_context_parameter_string("app.js");
-        fedy.application.set_option_context_description("");
-        fedy.application.set_option_context_summary(
-            "  fedy --list [--thick]\n" +
-            "  fedy [--force] [--status <plugin>]... [--undo <plugin>]... [--exec <plugin>]..."
-        );
+
+        if (typeof fedy.application.set_option_context_summary !== "undefined") {
+            fedy.application.set_option_context_parameter_string("app.js");
+            fedy.application.set_option_context_description("");
+            fedy.application.set_option_context_summary(
+                "  fedy --list [--thick]\n" +
+                "  fedy [--force] [--status <plugin>]... [--undo <plugin>]... [--exec <plugin>]..."
+            );
+        }
 
         this.fedy.application.connect("handle_local_options", Lang.bind(this, this._onOptions));
     },

--- a/option.js
+++ b/option.js
@@ -1,0 +1,32 @@
+const GLib = imports.gi.GLib,
+    Lang = imports.lang;
+
+var Option = new Lang.Class({
+    Name: "Option",
+
+    _init(name, optionArg, desc, placeholder, isAction) {
+        this.name = name;
+        this.shortName = this.name.charCodeAt(0);
+        this.optionArg = optionArg;
+        this.desc = desc;
+        this.placeholder = placeholder;
+        this.isAction = isAction;
+    },
+
+    registerIn(application) {
+        application.add_main_option(
+            this.name, this.shortName, GLib.OptionFlags.IN_MAIN, this.optionArg, this.desc, this.placeholder);
+    },
+
+    in(options) {
+        return options.contains(this.name);
+    },
+
+    match(optionName) {
+        return this.name === optionName;
+    },
+
+    parameters(options) {
+        return options.lookup_value(this.name, null).get_strv();
+    }
+});

--- a/repository.js
+++ b/repository.js
@@ -1,0 +1,98 @@
+const Lang = imports.lang;
+
+var PluginStatus = new Lang.Class({
+    Name: "PluginStatus",
+
+    _init(code, action, isMalicious, maliciousPart, maliciousDescription) {
+        this.code = code;
+        this.action = action;
+        this.isMalicious = isMalicious;
+        this.maliciousPart = maliciousPart;
+        this.maliciousDescription = maliciousDescription;
+    },
+
+    isPluginEnable() {
+        return this.code === 0;
+    }
+});
+
+var Plugin = new Lang.Class({
+    Name: "Plugin",
+
+    _init(name, plugin) {
+        this.name = name;
+        this.label = plugin.label;
+        this.description = plugin.description;
+        this.license = plugin.license;
+        this.category = plugin.category;
+        this.path = plugin.path;
+        this.icon = plugin.icon;
+        if (typeof plugin.scripts !== "undefined") {
+            this.scripts = {
+                exec: plugin.scripts.exec,
+                undo: plugin.scripts.undo,
+                status: plugin.scripts.status
+            };
+        }
+    }
+});
+
+var PluginRepository = new Lang.Class({
+    Name: "PluginRepository",
+
+    _init(fedy) {
+        this.fedy = fedy;
+        this.fedy._loadConfig();
+        this.fedy._loadPlugins();
+
+        this.plugins = {};
+        for (let category in this.fedy._plugins) {
+            if (this.fedy._plugins.hasOwnProperty(category)) {
+                this._toPlugin(this.fedy._plugins[category]);
+                this.plugins = Object.assign({}, this.plugins, this.fedy._plugins[category]);
+            }
+        }
+    },
+
+    listCategories() {
+        return Object.keys(this.fedy._plugins).sort();
+    },
+
+    listByCategory(category) {
+        return Object.values(this.fedy._plugins[category]);
+    },
+
+    getByName(pluginName) {
+        return this.plugins.hasOwnProperty(pluginName) ? this.plugins[pluginName] : {name: pluginName};
+    },
+
+    promiseOfPluginStatus(plugin) {
+        return new Promise((resolve) => {
+            if (typeof plugin.label === "undefined") {
+                resolve(new PluginStatus());
+            }
+
+            this.fedy._getPluginStatus(plugin, (action, statusCode) => {
+                const [ isMalicious, maliciousPart, description ] = this.fedy._scanMaliciousCommand(plugin, action.command),
+                    pluginStatus = new PluginStatus(statusCode, action, isMalicious, maliciousPart, description);
+                resolve(pluginStatus);
+            });
+        });
+    },
+
+    promiseOfCommandStatus(path, command) {
+        return new Promise((resolve) => {
+            this.fedy._queueCommand(path, command, (pid, commandStatusCode) => {
+                resolve(commandStatusCode);
+            });
+        });
+    },
+
+    _toPlugin(plugins) {
+        Object.keys(plugins)
+            .forEach(pluginName => {
+                plugins[pluginName] = new Plugin(pluginName, plugins[pluginName]);
+            });
+    }
+});
+


### PR DESCRIPTION
Hey,

This PR proposes to add command line options to Fedy. It follows the proposal of issue #297 (closed) by @satya164, adding `--list`, `--status`, `--exec` and `--undo` options.

* **help** option
```sh
$ fedy --help
Usage:
  gjs [OPTION…] app.js

  fedy --list [--thick]
  fedy [--force] [--status <plugin>]... [--undo <plugin>]... [--exec <plugin>]...

Help Options:
  -h, --help                 Show help options
  ...

Application Options:
  -l, --list                 List available plugins
  -t, --thick                Compact output when listing available plugins
  -s, --status=<plugin>      Report plugin status
  -e, --exec=<plugin>        Execute plugin action
  -u, --undo=<plugin>        Undo plugin action
  -f, --force                Force plugins action
  --display=DISPLAY          X display to use
```
* **list** option
```sh
$ fedy --list # add --thick to use only one line per plugin
-------
Category: Apps
✗ [bittorrentsync] Resilio Sync
  Sync easily moves anything, anywhere - all the benefits of the cloud, none of the limitations.
  (Proprietary,Freemium)
✗ [brave] Brave Browser
  A privacy focused browser that blocks ads and trackers by default
  (Mozilla Public License 2.0)
✓ [chrome] Google Chrome
  A fast, simple and secure web browser, built for the modern web.
  (Freeware)
...
```
* **exec**, **undo**, **status** options
```sh
$ fedy --status chrome -s papirus --exec numix -e fedy --undo paper -u atom
-------
✓ Status of 'Google Chrome' enabled
✓ Status of 'Papirus icon theme' enabled
✓ Exec of 'Numix themes' (Install) successfully completed
✗ Exec of 'fedy' fail: plugin name unknown
✓ Undo of 'Paper themes' (Remove) successfully completed
✗ Undo of 'Atom' aborted: the plugin is trying to run the command 'rm -f /etc/yum.repos.d/_copr_mosquito-atom.repo' which might delete important files. Use -f option to force the execution.
```
* **force** option
```sh
$ fedy --force --undo atom
-------
✓ Undo of 'Atom' (Remove) successfully completed
```

### Notes
* Implementation limits its impact on existing `app.js`.  
* Under Gnome, the `run-as-root` policy triggers a modal which can be avoided using `sudo`,
* Commands that might contain malicious parts are disabled by default, hence the `--force` option,
* There is currently no unit tests (would require the introduction of [jasmine-gjs](https://github.com/ptomato/jasmine-gjs)). However, this has been tested on Fedora 27 and 28 fresh install (missing functions in F27 are in commit [ff2ae76](https://github.com/fedy/fedy/commit/ff2ae76b7c170a662dff310e0ddc318f9e42b832)). 

And I take this opportunity to thank you for Fedy :+1: 

