### PR TITLE
Adding the Moka icon theme

### DIFF
--- a/plugins/mokaicontheme.plugin/install.sh
+++ b/plugins/mokaicontheme.plugin/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dnf config-manager --add-repo https://download.opensuse.org/repositories/home:snwh:moka/Fedora_25/home:snwh:moka.repo
+dnf -y install moka-icon-theme

--- a/plugins/mokaicontheme.plugin/metadata.json
+++ b/plugins/mokaicontheme.plugin/metadata.json
@@ -1,0 +1,18 @@
+{
+	"icon": "moka",
+	"label": "Moka Icon Theme",
+	"description": "Moka is an open source FreeDesktop icon project by Sam Hewitt.",
+	"license": "CC BY-SA 4.0",
+	"category": "Themes",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root dnf -y remove moka-icon-theme"
+		},
+		"status": { "command": "rpm --quiet --query moka-icon-theme" }
+	}
+}

--- a/plugins/mokaicontheme.plugin/moka.png
+++ b/plugins/mokaicontheme.plugin/moka.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:013b2d385ea02419acb2e5f205b55464c02442500a35e8753519b1671fcac2aa
+size 1296


### PR DESCRIPTION
Hey,
This PR add the [Moka](https://snwh.org/moka) icon theme to Fedy.
It has been tested on a fresh Fedora 27 & 28 install.
Thanks