### PR TITLE
Add GoLand to Development Tools plugins

### DIFF
--- a/plugins/goland.plugin/install.sh
+++ b/plugins/goland.plugin/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel compat-libstdc++-296.i686 compat-libstdc++-33.i686 compat-libstdc++-33.x86_64 glibc.i686 ncurses-libs.i686
+
+CACHEDIR="/var/cache/fedy/goland";
+mkdir -p "$CACHEDIR"
+cd "$CACHEDIR"
+
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=GO&latest=true" -O - | grep -o "https://download.jetbrains.com/go/goland-[0-9a-z.]*.tar.gz" | head -n 1)
+FILE=${URL##*/}
+
+wget -c "$URL" -O "$FILE"
+
+if [[ ! -f "$FILE" ]]; then
+	exit 1
+fi
+
+tar -xzf "$FILE" -C "/opt/"
+
+mv /opt/GoLand* "/opt/GoLand"
+ln -sf "/opt/GoLand/bin/goland.sh" "/usr/bin/goland"
+
+xdg-icon-resource install --novendor --size 128 "/opt/GoLand/bin/goland.png" "goland"
+gtk-update-icon-cache -f -t /usr/share/icons/hicolor
+
+cat <<EOF | tee /usr/share/applications/goland.desktop
+[Desktop Entry]
+Name=GoLand
+Icon=goland
+Comment=A Clever IDE to Go
+Exec=goland
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=IDE;Development;
+Keywords=Jetbrains;Go;GoLang;IDE;
+EOF

--- a/plugins/goland.plugin/metadata.json
+++ b/plugins/goland.plugin/metadata.json
@@ -1,0 +1,19 @@
+{
+	"icon": "goland",
+	"label": "GoLand",
+	"description": "A Clever IDE to Go",
+	"license": "Commercial",
+	"proprietary": true,
+	"category": "Development Tools",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root -s uninstall.sh"
+		},
+		"status": { "command": "test -f /opt/GoLand/bin/goland.sh" }
+	}
+}

--- a/plugins/goland.plugin/uninstall.sh
+++ b/plugins/goland.plugin/uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+xdg-icon-resource uninstall --novendor --size 128 "goland"
+
+gtk-update-icon-cache -f -t /usr/share/icons/hicolor
+
+rm -f "/usr/bin/goland"
+rm -f "/usr/share/applications/goland.desktop"
+rm -rf "/opt/GoLand"


### PR DESCRIPTION
I have added the GoLand jetbrains IDE to the Development tools. The jetbrains release information is located at https://data.services.jetbrains.com/products/releases?code=GO&latest=true in the format of https://download.jetbrains.com/go/goland-[a-z0-9].tar.gz