### PR TITLE
Fix Appdata install dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ uninstall:
 	rm -f $(DESTDIR)/usr/bin/fedy
 
 	rm -f $(DESTDIR)/usr/share/applications/org.folkswithhats.fedy.desktop
-	rm -f $(DESTDIR)/usr/share/appdata/fedy.appdata.xml
+	rm -f $(DESTDIR)/usr/share/metainfo/fedy.appdata.xml
 
 	rm -f $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/fedy.svg
 	rm -f $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/fedy-symbolic.svg


### PR DESCRIPTION
According to the Appstream specifications, Appdata files must now be installed in /usr/share/metainfo. /usr/share/appdata is a legacy path.

See: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html
and: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html